### PR TITLE
fix link to Zed website in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zed Fonts
 **Zed Mono** & **Zed Sans** are custom builds of [Iosevka](https://github.com/be5invis/Iosevka) liscensed under the SIL Open Font License, Version 1.1.
 
-They are built for use in [Zed](zed.dev). **Zed Sans** uses a quasi-proportional spacing to allow the font to still feel monospace while not having such wide gaps in a UI setting.
+They are built for use in [Zed](https://zed.dev/). **Zed Sans** uses a quasi-proportional spacing to allow the font to still feel monospace while not having such wide gaps in a UI setting.
 
 You can read the license here: [README.md](https://github.com/zed-industries/zed-fonts/blob/main/LICENSE.md).
 


### PR DESCRIPTION
Love this font and have used it for a while.

I found a link error: `zed.dev` will jump to 404 because it is a relative path, and can be solved by adding `https://`