### PR TITLE
Fixing LICENSE.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Zed Fonts
+
 **Zed Mono** & **Zed Sans** are custom builds of [Iosevka](https://github.com/be5invis/Iosevka) liscensed under the SIL Open Font License, Version 1.1.
 
 They are built for use in [Zed](https://zed.dev/). **Zed Sans** uses a quasi-proportional spacing to allow the font to still feel monospace while not having such wide gaps in a UI setting.
 
-You can read the license here: [README.md](https://github.com/zed-industries/zed-fonts/blob/main/LICENSE.md).
+You can read the license here: [LICENSE.md](https://github.com/zed-industries/zed-fonts/blob/main/LICENSE.md).
 
 ## Building Zed Mono
 


### PR DESCRIPTION
In the README.md file there was a little typo. It was saying `README.md` at the place where it was mentioning `LICENSE.md`.
I noticed it while going through about the zed font, so thought I could help.
By the way, Zed mono is the most amazing font I have ever used.