### PR TITLE
fix: correct typo in README (licensed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Zed Fonts
-**Zed Mono** & **Zed Sans** are custom builds of [Iosevka](https://github.com/be5invis/Iosevka) liscensed under the SIL Open Font License, Version 1.1.
+**Zed Mono** & **Zed Sans** are custom builds of [Iosevka](https://github.com/be5invis/Iosevka) licensed under the SIL Open Font License, Version 1.1.
 
 They are built for use in [Zed](https://zed.dev/). **Zed Sans** uses a quasi-proportional spacing to allow the font to still feel monospace while not having such wide gaps in a UI setting.
 


### PR DESCRIPTION
Corrected the misspelling of the word "licensed" in the README file.